### PR TITLE
Change prototypes_controller.rb#create

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -15,7 +15,7 @@ class PrototypesController < ApplicationController
     if @prototype.save
       redirect_to :root, notice: 'New prototype was successfully created'
     else
-      redirect_to ({ action: new }), alert: 'YNew prototype was unsuccessfully created'
+      redirect_to ({ action: :new }), alert: 'YNew prototype was unsuccessfully created'
      end
   end
 


### PR DESCRIPTION
redirect_toのaction名の指定方法をハッシュ形式に修正